### PR TITLE
dev-env: to support user-auth

### DIFF
--- a/doc-site/docs/guides/dev-experience.md
+++ b/doc-site/docs/guides/dev-experience.md
@@ -16,5 +16,5 @@ Now your service will have access to any dependencies within a namespace running
 
   1. Run `start-dev-env.sh` - You will be dropped into a shell that is the same as your local machine, but works as if it were running inside a pod in your k8s cluster
   2. Change code and run the server - As you run your local server, using local code, it will have access to remote dependencies, and will be sent traffic by the load balancer
-  3. Test on your cloud environment with real dependencies - `https://<your name>-<DOMAIN>`
+  3. Test on your cloud environment with real dependencies - `https://<your name>.dev.<DOMAIN>`
   4. git commit & auto-deploy to Staging through the build pipeline

--- a/templates/kubernetes/overlays/dev/auth.yml
+++ b/templates/kubernetes/overlays/dev/auth.yml
@@ -6,8 +6,13 @@ kind: Rule
 metadata:
   name: public-backend-endpoints
 spec:
+  upstream:
+    # DEV_NAMESPACE is filled in by start-dev-env.sh
+    url: http://<% .Name %>.$DEV_NAMESPACE
+    stripPath: /$DEV_NAMESPACE
+    preserveHost: true
   match:
-    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/<(status|webhook)\/.*>
+    url: http://$DEV_NAMESPACE.dev.<% index .Params `stagingHostRoot` %>/<(status|webhook)\/.*>
 ---
 ## Backend User-restricted endpoint
 # pattern: http://<proxy>/<not `status`/`.ory/kratos`>, everything else should be authenticated
@@ -20,5 +25,19 @@ kind: Rule
 metadata:
   name: authenticated-backend-endpoints
 spec:
+  upstream:
+    preserveHost: true
+    url: http://<% .Name %>.$DEV_NAMESPACE
+    stripPath: /$DEV_NAMESPACE
   match:
-    url: http://<% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>/<(?!(status|webhook|\.ory\/kratos)).*>
+    url: http://$DEV_NAMESPACE.dev.<% index .Params `stagingHostRoot` %>/<(?!(status|webhook|\.ory\/kratos)).*>
+  authenticators:
+    - handler: cookie_session
+      config:
+        check_session_url: http://kratos-development-public.user-auth/sessions/whoami
+  mutators:
+    - handler: id_token
+      config:
+        issuer_url: https://dev.<% index .Params `stagingHostRoot` %>
+    - handler: header
+

--- a/templates/kubernetes/overlays/dev/auth.yml
+++ b/templates/kubernetes/overlays/dev/auth.yml
@@ -8,11 +8,11 @@ metadata:
 spec:
   upstream:
     # DEV_NAMESPACE is filled in by start-dev-env.sh
-    url: http://<% .Name %>.$DEV_NAMESPACE
-    stripPath: /$DEV_NAMESPACE
+    url: http://<% .Name %>.{{ DEV_NAMESPACE }}
+    stripPath: /{{ DEV_NAMESPACE }}
     preserveHost: true
   match:
-    url: http://$DEV_NAMESPACE.dev.<% index .Params `stagingHostRoot` %>/<(status|webhook)\/.*>
+    url: http://{{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>/<(status|webhook)\/.*>
 ---
 ## Backend User-restricted endpoint
 # pattern: http://<proxy>/<not `status`/`.ory/kratos`>, everything else should be authenticated
@@ -27,10 +27,10 @@ metadata:
 spec:
   upstream:
     preserveHost: true
-    url: http://<% .Name %>.$DEV_NAMESPACE
-    stripPath: /$DEV_NAMESPACE
+    url: http://<% .Name %>.{{ DEV_NAMESPACE }}
+    stripPath: /{{ DEV_NAMESPACE }}
   match:
-    url: http://$DEV_NAMESPACE.dev.<% index .Params `stagingHostRoot` %>/<(?!(status|webhook|\.ory\/kratos)).*>
+    url: http://{{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>/<(?!(status|webhook|\.ory\/kratos)).*>
   authenticators:
     - handler: cookie_session
       config:

--- a/templates/kubernetes/overlays/dev/ingress.yml
+++ b/templates/kubernetes/overlays/dev/ingress.yml
@@ -52,19 +52,19 @@ metadata:
 
 spec:
   rules:
-  - host: <% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>
+  - host: {{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>
     http:
       paths:
         - path: /(.*)
           backend:
           <%- if eq (index .Params `userAuth`) "yes" %>
             serviceName: oathkeeper
-            servicePort: http
+            servicePort: 4455
           <%- else %>
             serviceName: <% .Name %>
             servicePort: http
           <%- end %>
   tls:
   - hosts:
-    - <% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>
+    - {{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>
     secretName: <% .Name %>-tls-secret

--- a/templates/kubernetes/overlays/dev/ingress.yml
+++ b/templates/kubernetes/overlays/dev/ingress.yml
@@ -1,3 +1,14 @@
+<%- if eq (index .Params `userAuth`) "yes" %>
+## Allows cross namespace ingress -> service
+apiVersion: v1
+kind: Service
+metadata:
+  name: oathkeeper
+spec:
+  type: ExternalName
+  externalName: oathkeeper-<% .Name %>-proxy.user-auth.svc.cluster.local
+---
+<%- end %>
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -12,7 +23,7 @@ metadata:
     # CORS
     ## to support both frontend origin and 'localhost', need 'configuration-snippet' implementation here, because 'cors-allow-origin' field doesn't support multiple originss yet.
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($http_origin ~* "^https?://((?:<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>)|(?:localhost))") {
+      if ($http_origin ~* "^https?://((?:<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>)|(?:localhost))|(?:127.0.0.1))") {
         set $cors "true";
       }
       if ($request_method = 'OPTIONS') {
@@ -21,7 +32,7 @@ metadata:
 
       if ($cors = "true") {
         add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
         add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, PATCH, OPTIONS' always;
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
@@ -29,7 +40,7 @@ metadata:
 
       if ($cors = "trueoptions") {
         add_header 'Access-Control-Allow-Origin' "$http_origin";
-        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
         add_header 'Access-Control-Allow-Methods' 'GET, PUT, POST, DELETE, PATCH, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
@@ -46,8 +57,13 @@ spec:
       paths:
         - path: /(.*)
           backend:
+          <%- if eq (index .Params `userAuth`) "yes" %>
+            serviceName: oathkeeper
+            servicePort: http
+          <%- else %>
             serviceName: <% .Name %>
             servicePort: http
+          <%- end %>
   tls:
   - hosts:
     - <% index .Params `stagingBackendSubdomain` %><% index .Params `stagingHostRoot` %>

--- a/templates/start-dev-env.sh
+++ b/templates/start-dev-env.sh
@@ -7,6 +7,7 @@ PROJECT_NAME=<% .Name %>
 ENVIRONMENT=stage
 ACCOUNT_ID=<% index .Params `accountId` %>
 REGION=<% index .Params `region` %>
+CLUSTER_CONTEXT=${PROJECT_NAME}-${ENVIRONMENT}-${REGION}
 
 # common functions
 function usage() {
@@ -52,7 +53,6 @@ DEV_PROJECT_ID=${1:-""}
 echo '[Dev Environment]'
 
 # Validate cluster
-CLUSTER_CONTEXT=${PROJECT_NAME}-${ENVIRONMENT}-${REGION}
 echo "  Cluster context: ${CLUSTER_CONTEXT}"
 
 # Validate secret
@@ -84,7 +84,7 @@ kubectl --context ${CLUSTER_CONTEXT} get sa ${SERVICE_ACCOUNT} -n ${DEV_NAMESPAC
 # Setup dev k8s manifests, configuration, docker login etc
 CONFIG_ENVIRONMENT="dev"
 EXT_HOSTNAME=<% index .Params `stagingBackendSubdomain`  %><% index .Params `stagingHostRoot` %>
-MY_EXT_HOSTNAME=${DEV_NAMESPACE}-${EXT_HOSTNAME}
+MY_EXT_HOSTNAME="${DEV_NAMESPACE}.dev.${EXT_HOSTNAME}"
 ECR_REPO=${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${PROJECT_NAME}
 VERSION_TAG=latest
 DATABASE_NAME=<% index .Params `databaseName` %>
@@ -114,6 +114,7 @@ fi
 (cd kubernetes/overlays/${CONFIG_ENVIRONMENT} && \
     kustomize build . | \
     sed "s|${EXT_HOSTNAME}|${MY_EXT_HOSTNAME}|g" | \
+    sed "s|\$DEV_NAMESPACE|${DEV_NAMESPACE}|g" | \
     sed "s|DATABASE_NAME: ${DATABASE_NAME}|DATABASE_NAME: ${DEV_DATABASE_NAME}|g" | \
     kubectl --context ${CLUSTER_CONTEXT} -n ${DEV_NAMESPACE} apply -f - ) || error_exit "Failed to apply kubernetes manifests"
 
@@ -149,7 +150,11 @@ echo
 
 # Starting dev environment with telepresence shell
 echo
-telepresence --context ${CLUSTER_CONTEXT} --swap-deployment ${PROJECT_NAME} --namespace ${DEV_NAMESPACE} --expose 80 --run-shell
+telepresence \
+  --context ${CLUSTER_CONTEXT} --namespace ${DEV_NAMESPACE} \
+  intercept ${PROJECT_NAME} \
+  --port 80 \
+  -- bash
 
 # Ending dev environment
 ## delete the most of resources (except ingress related, as we hit rate limit of certificate issuer(letsencrypt)

--- a/templates/start-dev-env.sh
+++ b/templates/start-dev-env.sh
@@ -114,8 +114,9 @@ fi
 (cd kubernetes/overlays/${CONFIG_ENVIRONMENT} && \
     kustomize build . | \
     sed "s|${EXT_HOSTNAME}|${MY_EXT_HOSTNAME}|g" | \
-    sed "s|\$DEV_NAMESPACE|${DEV_NAMESPACE}|g" | \
-    sed "s|DATABASE_NAME: ${DATABASE_NAME}|DATABASE_NAME: ${DEV_DATABASE_NAME}|g" | \
+    sed "s|{{ DEV_NAMESPACE }}|${DEV_NAMESPACE}|g" | \
+    sed "s|DATABASE_NAME: ${DATABASE_NAME}|DATABASE_NAME: ${DEV_DATABASE_NAME}|g" > kustomizebuild
+    exit 1
     kubectl --context ${CLUSTER_CONTEXT} -n ${DEV_NAMESPACE} apply -f - ) || error_exit "Failed to apply kubernetes manifests"
 
 # Confirm deployment


### PR DESCRIPTION
this requires a separate shared kratos to be spun up for dev
endpoints will change to the following format:
previously: <developer-namespace>.<domain>
auth endpoints:    dev.<domain>
backend endpoints: <developer-namespace>.dev.<domain>
and cookies for auth would be set on dev.<domain> so can share session