### PR TITLE
fix: correct behaviour if Redis was chosen as cache store (closes #47)

### DIFF
--- a/templates/src/app.js
+++ b/templates/src/app.js
@@ -31,7 +31,7 @@ app.use("/auth", authRoutes);<% end %>
 
 const port = process.env.SERVER_PORT || 8080;
 
-<%if ne (index .Params `cacheStore`) "none" %>
+<%if eq (index .Params `cacheStore`) "memcached" %>
 function touchCacheStore() {
   // memcached example getting and setting key value
   cacheStore.set('foo', 'bar', 10,
@@ -49,7 +49,7 @@ function touchCacheStore() {
 
 const main = async () => {
   // remove this block for development, just for verifying DB
-  <% if ne (index .Params `cacheStore`) "none" %>touchCacheStore();<% end %>
+  <% eq (index .Params `cacheStore`) "memcached" %>touchCacheStore();<% end %>
   try {
     await dbDatasource.authenticate();
     console.log("Connection has been established successfully.");

--- a/templates/src/app.js
+++ b/templates/src/app.js
@@ -31,7 +31,7 @@ app.use("/auth", authRoutes);<% end %>
 
 const port = process.env.SERVER_PORT || 8080;
 
-<%if eq (index .Params `cacheStore`) "memcached" %>
+<% if eq (index .Params `cacheStore`) "memcached" %>
 function touchCacheStore() {
   // memcached example getting and setting key value
   cacheStore.set('foo', 'bar', 10,
@@ -49,7 +49,7 @@ function touchCacheStore() {
 
 const main = async () => {
   // remove this block for development, just for verifying DB
-  <% eq (index .Params `cacheStore`) "memcached" %>touchCacheStore();<% end %>
+  <% if eq (index .Params `cacheStore`) "memcached" %>touchCacheStore();<% end %>
   try {
     await dbDatasource.authenticate();
     console.log("Connection has been established successfully.");


### PR DESCRIPTION
This module doesn't yet support redis, but the check in the code wasn't consistently checking the value of the `cacheStore` parameter, resulting in errors since some code was being properly excluded in the templating phase but some was not.﻿
