### PR TITLE
fix: dev-env outdated configs and bugs

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -83,16 +83,16 @@ A Kubernetes secret will exist in your application namespace (<% .Name %>) that 
 
 ## Secrets
 Along with the database credentials, any other secrets that need to be provided to the application can be managed in AWS Secrets Manager.
-Secrets have been created for each environment called `<% .Name %>/kubernetes/<environment>/<% .Name %>` which contain a list of environment variables that will be synced with the kubernetes secret in your namespace via a tool called [external-secrets](https://github.com/external-secrets/kubernetes-external-secrets)
+Secrets have been created for each environment called `<% .Name %>/application/<environment>/<% .Name %>` which contain a list of environment variables that will be synced with the kubernetes secret in your namespace via a tool called [external-secrets](https://github.com/external-secrets/kubernetes-external-secrets)
 Any secrets managed by `external-secrets` will be synced to kubernetes every 15 seconds. Keep in mind that any changes must be made in Secrets Manager, as any that are made to the secret on the kubernetes side will be overwritten.
 You can see the `external-secrets` configuration in [kubernetes/overlays/staging/external-secret.yml](./kubernetes/overlays/staging/external-secret.yml) (this is the one for staging)
 
 To work with the secret in AWS you can use the web interface or the cli tool:
 ```
- aws secretsmanager get-secret-value --secret=<% .Name %>/kubernetes/stage/<% .Name %>
+ aws secretsmanager get-secret-value --secret=<% .Name %>/application/stage/<% .Name %>
 ```
 
-The intent is that the last part of the secret name is the component of your application this secret is for. For example: if you were adding a new billing service, the secret might be called `<% .Name %>/kubernetes/stage/billing`
+The intent is that the last part of the secret name is the component of your application this secret is for. For example: if you were adding a new billing service, the secret might be called `<% .Name %>/application/stage/billing`
 
 ## Cron Jobs
 An example cron job is specified in [kubernetes/base/cronjob.yml][base-cronjob].

--- a/templates/kubernetes/overlays/dev/deployment.yml
+++ b/templates/kubernetes/overlays/dev/deployment.yml
@@ -5,6 +5,9 @@ metadata:
 spec:
   template:
     spec:
+      # To enable the backend-service account, you can add an entry from infrastructure repo
+      # kubernetes/terraform/environments/stage/main.tf's application_policy_list for dev namespaces
+      serviceAccountName: default
       containers:
         - name: <% .Name %>
           image: <% index .Params `accountId` %>.dkr.ecr.<% index .Params `region` %>.amazonaws.com/<% .Name %>:last-deployed

--- a/templates/kubernetes/overlays/dev/external-secret.yml
+++ b/templates/kubernetes/overlays/dev/external-secret.yml
@@ -8,4 +8,4 @@ metadata:
 spec:
   backendType: secretsManager
   dataFrom:
-  - <% .Name %>/kubernetes/stage/devenv-<% .Name %>
+  - <% .Name %>/application/stage/devenv-<% .Name %>

--- a/templates/kubernetes/overlays/dev/ingress.yml
+++ b/templates/kubernetes/overlays/dev/ingress.yml
@@ -23,7 +23,7 @@ metadata:
     # CORS
     ## to support both frontend origin and 'localhost', need 'configuration-snippet' implementation here, because 'cors-allow-origin' field doesn't support multiple originss yet.
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($http_origin ~* "^https?://((?:<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>)|(?:localhost))|(?:127.0.0.1))") {
+      if ($http_origin ~* "^https?:\/\/((?:<% index .Params `stagingFrontendSubdomain` %><% index .Params `stagingHostRoot` %>)|(?:localhost)|(?:127.0.0.1))") {
         set $cors "true";
       }
       if ($request_method = 'OPTIONS') {
@@ -52,7 +52,7 @@ metadata:
 
 spec:
   rules:
-  - host: {{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>
+  - host: "{{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>"
     http:
       paths:
         - path: /(.*)
@@ -66,5 +66,5 @@ spec:
           <%- end %>
   tls:
   - hosts:
-    - {{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>
+    - "{{ DEV_NAMESPACE }}.dev.<% index .Params `stagingHostRoot` %>"
     secretName: <% .Name %>-tls-secret

--- a/templates/start-dev-env.sh
+++ b/templates/start-dev-env.sh
@@ -115,8 +115,7 @@ fi
     kustomize build . | \
     sed "s|${EXT_HOSTNAME}|${MY_EXT_HOSTNAME}|g" | \
     sed "s|{{ DEV_NAMESPACE }}|${DEV_NAMESPACE}|g" | \
-    sed "s|DATABASE_NAME: ${DATABASE_NAME}|DATABASE_NAME: ${DEV_DATABASE_NAME}|g" > kustomizebuild
-    exit 1
+    sed "s|DATABASE_NAME: ${DATABASE_NAME}|DATABASE_NAME: ${DEV_DATABASE_NAME}|g"
     kubectl --context ${CLUSTER_CONTEXT} -n ${DEV_NAMESPACE} apply -f - ) || error_exit "Failed to apply kubernetes manifests"
 
 # Confirm deployment


### PR DESCRIPTION
a few problems with the dev-env 

- pointing to new secret prefix `kubernetes` > `application`
- `kustomize build errors out with `{{ }}` brackets before sed replacing without double quotes
- testing exit and output file wasnt removed 
- service account `backend-service` isnt avaiable for  on-demand dev namespaces
- syntax/escape error with the cors snippet 